### PR TITLE
Merge rumseyn/update_db_schema

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -197,4 +197,4 @@ The process should yield a bearer token in the HTTPS request Courier generates. 
 It's worth noting that the application is only configured for email use through Courier, but Courier supports a variety of modern notification methods.
 
 ## Database Schema
-![Schema](https://github.com/OSU-MC/MyClassroom/assets/25465133/d987e780-fd0e-4ea5-bd18-c72de5d8c32c)
+![Schema](https://github.com/user-attachments/assets/cc642b55-d099-46cd-a5c4-95efee36c15e)

--- a/server/app/models/course.js
+++ b/server/app/models/course.js
@@ -60,6 +60,7 @@ module.exports = (sequelize, DataTypes) => {
         Course.hasMany(models.Enrollment)
         Course.hasMany(models.Section)
         Course.hasMany(models.Lecture)
+        Course.hasMany(models.Question)
     }
 
     return Course

--- a/server/app/models/course.js
+++ b/server/app/models/course.js
@@ -50,13 +50,6 @@ module.exports = (sequelize, DataTypes) => {
         publishedAt: {
             type: DataTypes.DATE,
             allowNull: true,
-            validate: {
-                isPublishedIfNotNull(value) {
-                    if (value !== null && !this.published) {
-                        throw new Error("The 'published' field must be true if 'publishedAt' is not null.");
-                    }
-                }
-            }
         },
     },
     {

--- a/server/app/models/course.js
+++ b/server/app/models/course.js
@@ -48,7 +48,7 @@ module.exports = (sequelize, DataTypes) => {
             defaultValue: false
         },
         publishedAt: {
-            type: DataTypes.DATETIME,
+            type: DataTypes.DATE,
             allowNull: true,
             validate: {
                 isPublishedIfNotNull(value) {

--- a/server/app/models/course.js
+++ b/server/app/models/course.js
@@ -41,7 +41,23 @@ module.exports = (sequelize, DataTypes) => {
             type: DataTypes.BOOLEAN,
             allowNull: false,
             defaultValue: false
-        }
+        },
+        softDelete: {
+            type: DataTypes.BOOLEAN,
+            allowNull: false,
+            defaultValue: false
+        },
+        publishedAt: {
+            type: DataTypes.DATETIME,
+            allowNull: true,
+            validate: {
+                isPublishedIfNotNull(value) {
+                    if (value !== null && !this.published) {
+                        throw new Error("The 'published' field must be true if 'publishedAt' is not null.");
+                    }
+                }
+            }
+        },
     },
     {
         timestamps: true
@@ -51,7 +67,6 @@ module.exports = (sequelize, DataTypes) => {
         Course.hasMany(models.Enrollment)
         Course.hasMany(models.Section)
         Course.hasMany(models.Lecture)
-        Course.hasMany(models.Question)
     }
 
     return Course

--- a/server/app/models/enrollment.js
+++ b/server/app/models/enrollment.js
@@ -91,6 +91,18 @@ module.exports = (sequelize, DataTypes) => {
 					},
 				},
 			},
+			softDelete: {
+				type: DataTypes.BOOLEAN,
+				allowNull: false,
+				defaultValue: false
+			},
+			// this is a flag that is set to true when a student unenrolls from a course, but we want to keep the 
+			// record and associated grades
+			softUnenroll: {
+				type: DataTypes.BOOLEAN,
+				allowNull: false,
+				defaultValue: false
+			}
 		},
 		{
 			indexes: [

--- a/server/app/models/grades.js
+++ b/server/app/models/grades.js
@@ -77,6 +77,11 @@ module.exports = (sequelize, DataTypes) => {
 				type: DataTypes.INTEGER,
 				allowNull: true,
 			},
+			softDelete: {
+				type: DataTypes.BOOLEAN,
+				allowNull: false,
+				defaultValue: false
+			},
 		},
 		{
 			timestamps: false,

--- a/server/app/models/lecture.js
+++ b/server/app/models/lecture.js
@@ -94,7 +94,6 @@ module.exports = (sequelize, DataTypes) => {
 
     Lecture.associate = (models) => {
         Lecture.belongsTo(models.Course)
-        Lecture.hasMany(models.Question)
         Lecture.hasMany(models.QuestionInLecture)
         Lecture.hasMany(models.LectureForSection)
     }

--- a/server/app/models/lecture.js
+++ b/server/app/models/lecture.js
@@ -49,6 +49,19 @@ module.exports = (sequelize, DataTypes) => {
                 }
             }
         },
+        softDelete: {
+            type: DataTypes.BOOLEAN,
+            allowNull: false,
+            defaultValue: false
+        },
+        // The "archived" field marks lectures that were live and then closed, preserving their state and questions. 
+        //      Archived lectures are excluded from the lecture template view, and are only used to preserve state of a 
+        //      previously held lecture.
+        archived: {
+            type: DataTypes.BOOLEAN,
+            allowNull: false,
+            defaultValue: false
+        },
     },
     {
         hooks: {
@@ -81,6 +94,7 @@ module.exports = (sequelize, DataTypes) => {
 
     Lecture.associate = (models) => {
         Lecture.belongsTo(models.Course)
+        Lecture.hasMany(models.Question)
         Lecture.hasMany(models.QuestionInLecture)
         Lecture.hasMany(models.LectureForSection)
     }

--- a/server/app/models/lecture_for_section.js
+++ b/server/app/models/lecture_for_section.js
@@ -59,7 +59,7 @@ module.exports = (sequelize, DataTypes) => {
           defaultValue: false
       },
       publishedAt: {
-        type: DataTypes.DATETIME,
+        type: DataTypes.DATE,
         allowNull: true,
         validate: {
             isPublishedIfNotNull(value) {

--- a/server/app/models/lecture_for_section.js
+++ b/server/app/models/lecture_for_section.js
@@ -61,14 +61,7 @@ module.exports = (sequelize, DataTypes) => {
       publishedAt: {
         type: DataTypes.DATE,
         allowNull: true,
-        validate: {
-            isPublishedIfNotNull(value) {
-                if (value !== null && !this.published) {
-                    throw new Error("The 'published' field must be true if 'publishedAt' is not null.");
-                }
-            }
-        }
-    },
+      },
     },
     {
         indexes: [

--- a/server/app/models/lecture_for_section.js
+++ b/server/app/models/lecture_for_section.js
@@ -52,7 +52,23 @@ module.exports = (sequelize, DataTypes) => {
         participationScore: {
           type: DataTypes.DOUBLE,
           allowNull: true
+        },
+        softDelete: {
+          type: DataTypes.BOOLEAN,
+          allowNull: false,
+          defaultValue: false
+      },
+      publishedAt: {
+        type: DataTypes.DATETIME,
+        allowNull: true,
+        validate: {
+            isPublishedIfNotNull(value) {
+                if (value !== null && !this.published) {
+                    throw new Error("The 'published' field must be true if 'publishedAt' is not null.");
+                }
+            }
         }
+    },
     },
     {
         indexes: [

--- a/server/app/models/question.js
+++ b/server/app/models/question.js
@@ -13,11 +13,11 @@ module.exports = (sequelize, DataTypes) => {
 				autoIncrement: true,
 				primaryKey: true,
 			},
-			lectureId: {
+			courseId: {
 				type: DataTypes.INTEGER,
-				allowNull: true,
+				allowNull: false,
 				references: {
-					model: "Lectures",
+					model: "Courses",
 					key: "id",
 				},
 			},

--- a/server/app/models/question.js
+++ b/server/app/models/question.js
@@ -20,6 +20,11 @@ module.exports = (sequelize, DataTypes) => {
 					model: "Courses",
 					key: "id",
 				},
+				validate: {
+					notNull: {
+						msg: "Question must have a course"
+					},
+				},
 			},
 			type: {
 				// multiple choice only for now

--- a/server/app/models/question.js
+++ b/server/app/models/question.js
@@ -15,15 +15,10 @@ module.exports = (sequelize, DataTypes) => {
 			},
 			lectureId: {
 				type: DataTypes.INTEGER,
-				allowNull: false,
+				allowNull: true,
 				references: {
 					model: "Lectures",
 					key: "id",
-				},
-				validate: {
-					notNull: {
-						msg: "Question must be associated with a lecture",
-					},
 				},
 			},
 			type: {

--- a/server/app/models/question.js
+++ b/server/app/models/question.js
@@ -13,16 +13,16 @@ module.exports = (sequelize, DataTypes) => {
 				autoIncrement: true,
 				primaryKey: true,
 			},
-			courseId: {
+			lectureId: {
 				type: DataTypes.INTEGER,
 				allowNull: false,
 				references: {
-					model: "Courses",
+					model: "Lectures",
 					key: "id",
 				},
 				validate: {
 					notNull: {
-						msg: "Question must have a course",
+						msg: "Question must be associated with a lecture",
 					},
 				},
 			},
@@ -186,6 +186,11 @@ module.exports = (sequelize, DataTypes) => {
 					},
 				},
 			},
+			softDelete: {
+				type: DataTypes.BOOLEAN,
+				allowNull: false,
+				defaultValue: false
+			},
 		},
 		{
 			timestamps: true,
@@ -193,7 +198,7 @@ module.exports = (sequelize, DataTypes) => {
 	);
 
 	Question.associate = (models) => {
-		Question.belongsTo(models.Course);
+		Question.belongsTo(models.Lecture);
 		Question.hasMany(models.QuestionInLecture);
 	};
 

--- a/server/app/models/question.js
+++ b/server/app/models/question.js
@@ -198,7 +198,7 @@ module.exports = (sequelize, DataTypes) => {
 	);
 
 	Question.associate = (models) => {
-		Question.belongsTo(models.Lecture);
+		Question.belongsTo(models.Course);
 		Question.hasMany(models.QuestionInLecture);
 	};
 

--- a/server/app/models/question_in_lecture.js
+++ b/server/app/models/question_in_lecture.js
@@ -51,13 +51,6 @@ module.exports = (sequelize, DataTypes) => {
         publishedAt: {
             type: DataTypes.DATE,
             allowNull: true,
-            validate: {
-                isPublishedIfNotNull(value) {
-                    if (value !== null && !this.published) {
-                        throw new Error("The 'published' field must be true if 'publishedAt' is not null.");
-                    }
-                }
-            }
         },
     },
     {

--- a/server/app/models/question_in_lecture.js
+++ b/server/app/models/question_in_lecture.js
@@ -42,7 +42,23 @@ module.exports = (sequelize, DataTypes) => {
             type: DataTypes.BOOLEAN,
             defaultValue: false,
             allowNull: false
-        }
+        },
+        softDelete: {
+            type: DataTypes.BOOLEAN,
+            allowNull: false,
+            defaultValue: false
+        },
+        publishedAt: {
+            type: DataTypes.DATETIME,
+            allowNull: true,
+            validate: {
+                isPublishedIfNotNull(value) {
+                    if (value !== null && !this.published) {
+                        throw new Error("The 'published' field must be true if 'publishedAt' is not null.");
+                    }
+                }
+            }
+        },
     },
     {
         timestamps: true,

--- a/server/app/models/question_in_lecture.js
+++ b/server/app/models/question_in_lecture.js
@@ -49,7 +49,7 @@ module.exports = (sequelize, DataTypes) => {
             defaultValue: false
         },
         publishedAt: {
-            type: DataTypes.DATETIME,
+            type: DataTypes.DATE,
             allowNull: true,
             validate: {
                 isPublishedIfNotNull(value) {

--- a/server/app/models/response.js
+++ b/server/app/models/response.js
@@ -66,6 +66,11 @@ module.exports = (sequelize, DataTypes) => {
 				type: DataTypes.JSON,
 				defaultValue: {},
 			},
+			softDelete: {
+				type: DataTypes.BOOLEAN,
+				allowNull: false,
+				defaultValue: false
+			},
 		},
 		{
 			timestamps: true,

--- a/server/app/models/section.js
+++ b/server/app/models/section.js
@@ -41,6 +41,11 @@ module.exports = (sequelize, DataTypes) => {
                 }
             }
         },
+        softDelete: {
+            type: DataTypes.BOOLEAN,
+            allowNull: false,
+            defaultValue: false
+        },
     },
     {
         indexes: [

--- a/server/app/models/user.js
+++ b/server/app/models/user.js
@@ -128,7 +128,12 @@ module.exports = (sequelize, DataTypes) => {
             type: DataTypes.BOOLEAN,
             allowNull: false,
             defaultValue: false
-        }
+        },
+        softDelete: {
+            type: DataTypes.BOOLEAN,
+            allowNull: false,
+            defaultValue: false
+        },
     },
     { 
         timestamps: true,

--- a/server/db/migrations/20250114081211-support-soft-deletion-and-lecture-templates.js
+++ b/server/db/migrations/20250114081211-support-soft-deletion-and-lecture-templates.js
@@ -17,6 +17,10 @@ module.exports = {
       allowNull: false,
       defaultValue: false,
     });
+    await queryInterface.addColumn('Courses', 'publishedAt', {
+      type: Sequelize.DATE,
+      allowNull: true,
+    });
     await queryInterface.addColumn('Enrollments', 'softDelete', {
       type: Sequelize.BOOLEAN,
       allowNull: false,
@@ -92,6 +96,7 @@ module.exports = {
 
     // Remove softDelete and other new fields from relevant models
     await queryInterface.removeColumn('Courses', 'softDelete');
+    await queryInterface.removeColumn('Courses', 'publishedAt');
     await queryInterface.removeColumn('Enrollments', 'softDelete');
     await queryInterface.removeColumn('Enrollments', 'softUnenroll');
     await queryInterface.removeColumn('Grades', 'softDelete');

--- a/server/db/migrations/20250114081211-support-soft-deletion-and-lecture-templates.js
+++ b/server/db/migrations/20250114081211-support-soft-deletion-and-lecture-templates.js
@@ -80,18 +80,6 @@ module.exports = {
       allowNull: false,
       defaultValue: false,
     });
-
-    // Update Questions: Remove courseId and add lectureId
-    await queryInterface.removeColumn('Questions', 'courseId');
-    await queryInterface.addColumn('Questions', 'lectureId', {
-      type: Sequelize.INTEGER,
-      allowNull: true,
-      references: {
-        model: 'Lectures',
-        key: 'id',
-      },
-    });
-
   },
 
   async down(queryInterface, Sequelize) {
@@ -117,21 +105,5 @@ module.exports = {
     await queryInterface.removeColumn('Responses', 'softDelete');
     await queryInterface.removeColumn('Sections', 'softDelete');
     await queryInterface.removeColumn('Users', 'softDelete');
-
-    // Revert Questions: Remove lectureId and add courseId
-    await queryInterface.removeColumn('Questions', 'lectureId');
-    await queryInterface.addColumn('Questions', 'courseId', {
-      type: Sequelize.INTEGER,
-      allowNull: false,
-      references: {
-        model: 'Courses',
-        key: 'id',
-      },
-      validate: {
-        notNull: {
-          msg: 'Question must have a course',
-        },
-      },
-    });
   }
 };

--- a/server/db/migrations/20250114081211-support-soft-deletion-and-lecture-templates.js
+++ b/server/db/migrations/20250114081211-support-soft-deletion-and-lecture-templates.js
@@ -1,0 +1,137 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+
+    /**
+     * Add altering commands here.
+     *
+     * Example:
+     * await queryInterface.createTable('users', { id: Sequelize.INTEGER });
+     */
+
+    // Add softDelete to relevant models
+    await queryInterface.addColumn('Courses', 'softDelete', {
+      type: Sequelize.BOOLEAN,
+      allowNull: false,
+      defaultValue: false,
+    });
+    await queryInterface.addColumn('Enrollments', 'softDelete', {
+      type: Sequelize.BOOLEAN,
+      allowNull: false,
+      defaultValue: false,
+    });
+    await queryInterface.addColumn('Enrollments', 'softUnenroll', {
+      type: Sequelize.BOOLEAN,
+      allowNull: false,
+      defaultValue: false,
+    });
+    await queryInterface.addColumn('Grades', 'softDelete', {
+      type: Sequelize.BOOLEAN,
+      allowNull: false,
+      defaultValue: false,
+    });
+    await queryInterface.addColumn('Lectures', 'softDelete', {
+      type: Sequelize.BOOLEAN,
+      allowNull: false,
+      defaultValue: false,
+    });
+    await queryInterface.addColumn('Lectures', 'archived', {
+      type: Sequelize.BOOLEAN,
+      allowNull: false,
+      defaultValue: false,
+    });
+    await queryInterface.addColumn('LectureForSections', 'softDelete', {
+      type: Sequelize.BOOLEAN,
+      allowNull: false,
+      defaultValue: false,
+    });
+    await queryInterface.addColumn('LectureForSections', 'publishedAt', {
+      type: Sequelize.DATE,
+      allowNull: true,
+    });
+    await queryInterface.addColumn('Questions', 'softDelete', {
+      type: Sequelize.BOOLEAN,
+      allowNull: false,
+      defaultValue: false,
+    });
+    await queryInterface.addColumn('QuestionInLectures', 'softDelete', {
+      type: Sequelize.BOOLEAN,
+      allowNull: false,
+      defaultValue: false,
+    });
+    await queryInterface.addColumn('QuestionInLectures', 'publishedAt', {
+      type: Sequelize.DATE,
+      allowNull: true,
+    });
+    await queryInterface.addColumn('Responses', 'softDelete', {
+      type: Sequelize.BOOLEAN,
+      allowNull: false,
+      defaultValue: false,
+    });
+    await queryInterface.addColumn('Sections', 'softDelete', {
+      type: Sequelize.BOOLEAN,
+      allowNull: false,
+      defaultValue: false,
+    });
+    await queryInterface.addColumn('Users', 'softDelete', {
+      type: Sequelize.BOOLEAN,
+      allowNull: false,
+      defaultValue: false,
+    });
+
+    // Update Questions: Remove courseId and add lectureId
+    await queryInterface.removeColumn('Questions', 'courseId');
+    await queryInterface.addColumn('Questions', 'lectureId', {
+      type: Sequelize.INTEGER,
+      allowNull: true,
+      references: {
+        model: 'Lectures',
+        key: 'id',
+      },
+    });
+
+  },
+
+  async down(queryInterface, Sequelize) {
+    /**
+     * Add reverting commands here.
+     *
+     * Example:
+     * await queryInterface.dropTable('users');
+     */
+
+    // Remove softDelete and other new fields from relevant models
+    await queryInterface.removeColumn('Courses', 'softDelete');
+    await queryInterface.removeColumn('Enrollments', 'softDelete');
+    await queryInterface.removeColumn('Enrollments', 'softUnenroll');
+    await queryInterface.removeColumn('Grades', 'softDelete');
+    await queryInterface.removeColumn('Lectures', 'softDelete');
+    await queryInterface.removeColumn('Lectures', 'archived');
+    await queryInterface.removeColumn('LectureForSections', 'softDelete');
+    await queryInterface.removeColumn('LectureForSections', 'publishedAt');
+    await queryInterface.removeColumn('Questions', 'softDelete');
+    await queryInterface.removeColumn('QuestionInLectures', 'softDelete');
+    await queryInterface.removeColumn('QuestionInLectures', 'publishedAt');
+    await queryInterface.removeColumn('Responses', 'softDelete');
+    await queryInterface.removeColumn('Sections', 'softDelete');
+    await queryInterface.removeColumn('Users', 'softDelete');
+
+    // Revert Questions: Remove lectureId and add courseId
+    await queryInterface.removeColumn('Questions', 'lectureId');
+    await queryInterface.addColumn('Questions', 'courseId', {
+      type: Sequelize.INTEGER,
+      allowNull: false,
+      references: {
+        model: 'Courses',
+        key: 'id',
+      },
+      validate: {
+        notNull: {
+          msg: 'Question must have a course',
+        },
+      },
+    });
+  }
+};

--- a/server/db/seeders/20230202033013-add_api_test_data.js
+++ b/server/db/seeders/20230202033013-add_api_test_data.js
@@ -169,7 +169,7 @@ module.exports = {
 		"2": 1,
 		"3": 1
 	}`,
-				courseId: course1,
+				lectureId: lecture1course1,
 			},
 		]);
 
@@ -197,7 +197,7 @@ module.exports = {
           "2": 1,
           "3": 1
       }`,
-				courseId: course1,
+				lectureId: lecture1course1,
 			},
 		]);
 
@@ -262,7 +262,7 @@ module.exports = {
 			"2": 1,
 			"3": 1
 		}`,
-					courseId: course1,
+					lectureId: lecture1course1,
 				},
 			]);
 		}

--- a/server/db/seeders/20230202033013-add_api_test_data.js
+++ b/server/db/seeders/20230202033013-add_api_test_data.js
@@ -169,7 +169,7 @@ module.exports = {
 		"2": 1,
 		"3": 1
 	}`,
-				lectureId: lecture1course1,
+				courseId: course1,
 			},
 		]);
 
@@ -197,7 +197,7 @@ module.exports = {
           "2": 1,
           "3": 1
       }`,
-				lectureId: lecture1course1,
+				courseId: course1,
 			},
 		]);
 
@@ -262,7 +262,7 @@ module.exports = {
 			"2": 1,
 			"3": 1
 		}`,
-					lectureId: lecture1course1,
+					courseId: course1,
 				},
 			]);
 		}


### PR DESCRIPTION
# Pull Request Template
<!--Thank you for contributing to MyClassroom! Please fill out this template before submitting your PR.-->

## Screenshots
<!--If applicable, add screenshots to help explain your problem or feature.-->
New Database Schema
![New Database Schema](https://github.com/user-attachments/assets/cc642b55-d099-46cd-a5c4-95efee36c15e)

## Description
<!--Please include a summary of the change and which issue is fixed. Also, list any dependencies that are required for this change.-->
- Add `softDelete` field to each table (except Sessions) - will need code to handle cascading softDeletes.
- Add `publishedAt` field to `Courses`, `QuestionInLectures`, and `LectureForSection` tables
- Add `softUnenroll` field to `Enrollments` table (so if a student "leaves" a course it disappears from their feed, but it the enrollment is still not deleted and shows up on the instructor's list still but marked as "LEFT")
- Add field `archived` to table `Lectures` when a lecture was set to live and then closed. This provides an immutable reference to what the questions were at the time of the live lecture (i.e., if the lecture was changed later, the results of the lecture would not be messed up). Lecture template view does not show any lectures when `archived=true`.


Fixes # (partially) 256 

## Additional Information
<!--Any additional information, configuration, or data that might be necessary to reproduce the issue.-->
N/A

## Checklist:
Before you submit your Pull Request, please make sure you have completed the following tasks:
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I have tagged my PR with the appropriate label(s).
